### PR TITLE
Terminology update: "Last standup" instead of "yesterday"

### DIFF
--- a/pystandups/cli.py
+++ b/pystandups/cli.py
@@ -7,7 +7,7 @@ Usage:
     standup (--help | -h)
     standup today
     standup later
-    standup get yesterday
+    standup get last
     standup get today
 """
 
@@ -27,7 +27,7 @@ def main():
 
         if args["today"]:
             print(st().today["todo"])
-        elif args["yesterday"]:
+        elif args["last"]:
             print(st().get_done())
     else:
         if args["today"]:

--- a/pystandups/lib.py
+++ b/pystandups/lib.py
@@ -119,7 +119,7 @@ def set_today():
     with Standups() as standups:
         # User reviews done items (normally previous day's)
         done = standups.get_done()
-        print(f"Yesterday's standup was:\n{done}")
+        print(f"The previous standup was:\n{done}")
         if questionary.confirm("Edit?", default=done == "").ask():
             done = editor.edit(contents=done).decode()
         standups.today["done"] = done

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Standups are stored as a JSON dictionary. The location is hardcoded (see `DATA_D
 ## Usage
 * `standup today` - prepare standup at the beginning of the day. PyStandups will try to intelligently fill in as much information as possible, and you will have the opportunity to edit it in your editor.
 * `standup later` - take quick notes for future standups. `standup today` automatically fills in the data from `standup later`. For more sophisticated management of planned tasks, you should use an external tool like Jira.
-* `standup get today` and `standup get yesterday` - print the relevant standup to standard out. These are mainly intended for use in scripts.
+* `standup get today` and `standup get last` - print the relevant standup to standard out. These are mainly intended for use in scripts.
 
 ### Old Standups
 PyStandups does not support working with standups older than today or other complex tasks. You can use an external tool like `jq` to work with the JSON file directly.


### PR DESCRIPTION
"Yesterday" is a sloppy phrasing, because in some cases the previous standup may actually be several days ago. For example, when doing a standup on monday, you would logically expect the previous standup to be friday, not sunday.

The behavior of PyStandups was already following that concept, but the commands and output referred to "yesterday" because I couldn't think of a better word. Now it will mention the "last standup" instead.