### PR TITLE
Use XDG-based data directory, fix #7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ docopt = "*"
 openeditor = "^0.3.1"
 questionary = "*"
 tabulate = "*"
+xdg = "*"
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pystandups"
-version = "0.4.6"
+version = "0.4.7"
 description = "A command line utility for working with daily standups."
 authors = ["Azat Akhmetov"]
 readme = "readme.md"

--- a/pystandups/lib.py
+++ b/pystandups/lib.py
@@ -6,11 +6,12 @@ from typing import Dict
 
 import coloredlogs
 import dictdiffer
+import xdg
 from openeditor import edit_temp
 import questionary
 from tabulate import tabulate
 
-DATA_DIR = Path("~").expanduser() / ".local/share/pystandups"
+DATA_DIR = xdg.xdg_data_home() / "pystandups"
 STANDUPS_FILE = "standups.json"
 
 # Encourage editors to use markdown highlight for temp files


### PR DESCRIPTION
Should be compatible with existing ones, because the hardcoded directory was already the same as the new XDG dir.

- bump version
- add xdg to deps
- use xdg-based local data dir
